### PR TITLE
Encode requests to search engines

### DIFF
--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -107,7 +107,7 @@ Page {
         var valid = nonFixedUrl
         if (valid.indexOf(":")<0) {
             if (valid.indexOf(".")<0 || valid.indexOf(" ")>=0) {
-                return url = mainWindow.searchEngine.replace("%s",valid)
+                return url = mainWindow.searchEngine.replace("%s",encodeURIComponent(valid))
             } else {
                 return "http://"+valid;
             }


### PR DESCRIPTION
Add encodeURIComponent, so that typing "c++ test" in the search bar will make the search engine search for "c++ test", not "c   test".