### PR TITLE
Key Bindings Switch

### DIFF
--- a/harbour-webcat.pro
+++ b/harbour-webcat.pro
@@ -150,6 +150,7 @@ DISTFILES += \
     qml/pages/helper/es6-collections.min.js \
     qml/pages/helper/canvg.min.js \
     qml/pages/SplitWeb.qml \
+    qml/pages/KeyboardOverviewPage.qml \
     qml/pages/helper/otherComponents/SectionHeader.qml \
     translations/harbour-webcat-sv.ts \
     qml/pages/helper/otherComponents/MenuPopup.qml \

--- a/qml/harbour-webcat.qml
+++ b/qml/harbour-webcat.qml
@@ -82,6 +82,7 @@ ApplicationWindow
     property alias infoBanner: infoBanner
     property int coverActionGroup: 0
     property bool torProxyEnabled: false
+    property bool useBB10KeyboardShortcuts: true
 
     property var firstPage
     property TransferEngine transferEngine: TransferEngine { }

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -823,41 +823,12 @@ Page {
             flickable: webview
             y: toolbar.y - height
         }
+        KeyboardCommands {
+            id: keyboardCommands
+        }
         Keys.onPressed: {
             if (toolbar.urlText.focus == false && inputFocus == false) {
-                if (event.key == Qt.Key_T && !event.modifiers) webview.scrollToTop()
-                else if (event.key == Qt.Key_B) webview.scrollToBottom()
-                else if (event.key == Qt.Key_K) toolbar.gotoButton.clicked(undefined)
-                else if (event.key == Qt.Key_Q) toolbar.gotoButton.clicked(undefined)
-                else if (event.key == Qt.Key_A) toolbar.bookmarkButton.addFavorite();
-                else if (event.key == Qt.Key_S) extraToolbar.searchModeButton.clicked(undefined)
-                else if (event.key == Qt.Key_R) extraToolbar.readerModeButton.clicked(undefined)
-                else if (event.key == Qt.Key_L) webview.reload()
-                else if (event.key == Qt.Key_U) { toolbar.state = "expanded" ; toolbar.urlText.forceActiveFocus() }
-                else if (event.key == Qt.Key_W && event.modifiers == Qt.ShiftModifier) mainWindow.openNewWindow("about:bookmarks")
-                else if (event.key == Qt.Key_W && !event.modifiers) mainWindow.loadInNewTab("about:bookmarks");
-                else if (event.key == Qt.Key_P) webview.goBack()
-                else if (event.key == Qt.Key_N && !event.modifiers) webview.goForward()
-                else if (event.key == Qt.Key_Escape && !event.modifiers) webview.stop();
-                else if (searchBar.visible == true && (event.key == Qt.Key_Enter || event.key == Qt.Key_Return)) searchIcon.clicked(undefined)
-                else if (event.modifiers == Qt.ControlModifier) {
-                    if (event.key == Qt.Key_Tab && mainWindow.tabModel.count > 1) {
-                        mainWindow.switchToTab(mainWindow.tabModel.get(mainWindow.tabModel.nextTab()).pageid) // Tab forward
-                        event.accepted = true; }
-                    else if (event.key == Qt.Key_W && mainWindow.tabModel.count > 1) {
-                        mainWindow.closeTab(mainWindow.tabModel.getIndexFromId(mainWindow.currentTab),mainWindow.currentTab);
-                    }
-                    else if (event.key == Qt.Key_T) {
-                        mainWindow.loadInNewTab("about:bookmarks");
-                    }
-                    else if (event.key == Qt.Key_N) {
-                        mainWindow.openNewWindow("about:bookmarks")
-                    }
-                }
-                else if (event.key == Qt.Key_Backtab && event.modifiers & Qt.ControlModifier && mainWindow.tabModel.count > 1) {
-                    console.log("Backwards tab switch triggered with prevTab: " + mainWindow.tabModel.prevTab());
-                    mainWindow.switchToTab(mainWindow.tabModel.get(mainWindow.tabModel.prevTab()).pageid) // Tab backwards
-                    event.accepted = true; }
+                keyboardCommands.handleKeyPress(event)
             }
         }
 

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -1141,7 +1141,7 @@ Page {
         visible: searchMode
 
         function search() {
-            searchText.focus = false;  // Close keyboard
+            webview.forceActiveFocus();  // Close keyboard
             var message = new Object
             message.type = 'search'
             message.searchTerm = searchText.text
@@ -1153,7 +1153,7 @@ Page {
             id: closeSearchButton
             icon.source: "image://theme/icon-m-close"
             onClicked:  {
-                searchMode = false;
+                extraToolbar.searchModeButton.clicked(undefined)
             }
             anchors.right: parent.right
             anchors.rightMargin: Theme.paddingSmall
@@ -1191,6 +1191,11 @@ Page {
                searchBar.search();
                webview.forceActiveFocus();
             }
+
+            Keys.onEscapePressed: {
+                extraToolbar.searchModeButton.clicked(undefined)
+            }
+
 
         }
 

--- a/qml/pages/KeyboardOverviewPage.qml
+++ b/qml/pages/KeyboardOverviewPage.qml
@@ -1,0 +1,138 @@
+import QtQuick 2.2
+import Sailfish.Silica 1.0
+import "helper/browserComponents"
+
+Page {
+    id: keyboardPage
+    allowedOrientations: mainWindow.orient
+    property bool isBB10: true
+    KeyboardCommands {
+        id: keyboardCommands
+        isBB10: parent.isBB10
+    }
+    ListModel {
+        id: currentShortcutsModel
+    }
+    function readCommands(){
+        /* group current keys by method */
+        var tmpObj = {};
+        var commandEntry, tmpKey;
+        for(var keySettingsIndex = 0; keySettingsIndex < keyboardCommands.keyboardSettings.length; keySettingsIndex++) {
+            commandEntry = keyboardCommands.keyboardSettings[keySettingsIndex];
+            tmpKey = commandEntry.methods.join('|');
+
+            if(commandEntry.readableKeys && commandEntry.readableKeys.length > 0) {
+                tmpObj[tmpKey] = tmpObj[tmpKey] || {
+                    keys:[],
+                    methods: commandEntry.methods,
+                    descr: commandEntry.methods.map(function(methodName){
+                        return keyboardCommands.keyCommandsOverview[methodName].text
+                    }).join('<br>')
+                }
+                tmpObj[tmpKey].keys.push({combination: commandEntry.readableKeys.map(function(readableKey){return {key: readableKey};})})
+            }
+        }
+        /* fill model */
+        var tmpObjKeys = Object.keys(tmpObj);
+        currentShortcutsModel.clear();
+        for(var i = 0; i<tmpObjKeys.length;i++) {
+            console.log('append', i, JSON.stringify(tmpObj[tmpObjKeys[i]]))
+            currentShortcutsModel.append(tmpObj[tmpObjKeys[i]]);
+        }
+    }
+    Connections {
+        target: keyboardCommands
+        onStateChanged: readCommands()
+    }
+    PageHeader {
+        id: pageHeader
+        title: qsTr('Current Keyboard Shortcuts')
+        description: ''
+        extraContent.height: headerLabel.height
+        anchors.bottomMargin: headerLabel.height
+    }
+    Label {
+        id: headerLabel
+        anchors.top: pageHeader.bottom
+        width: parent.width - Theme.horizontalPageMargin * 2
+        x: Theme.horizontalPageMargin
+        wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+        font.pixelSize: Theme.fontSizeSmall
+        horizontalAlignment: Text.AlignRight
+        color: Theme.secondaryHighlightColor
+        text: keyboardPage.isBB10
+              ? qsTr('You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.')
+              : qsTr('You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.')
+    }
+    SilicaListView {
+        clip: true
+        width: parent.width
+        anchors.top: headerLabel.bottom
+        anchors.bottom: parent.bottom
+        model: currentShortcutsModel
+        delegate: Column {
+            width: keyboardPage.width
+            Row {
+                width: parent.width - Theme.horizontalPageMargin * 2
+                x: Theme.horizontalPageMargin
+                height: Math.max(keyColumn.height, commandLabel.height) + Theme.paddingMedium * 2
+                Column {
+                    id: keyColumn
+                    width: Theme.itemSizeExtraLarge * 2
+                    spacing: Theme.paddingMedium
+                    y: Theme.paddingMedium
+
+                    Repeater {
+                        model: keys
+                        delegate: Flow {
+                            width: keyColumn.width
+                            Repeater {
+                                model: combination
+                                delegate: Item {
+                                    width: plusLabel.width + keyLabel.width
+                                    height: keyLabel.height
+                                    Label {
+                                        id: plusLabel
+                                        text: '+'
+                                        visible: index > 0
+                                        width: visible ? implicitWidth : 0
+                                        horizontalAlignment: Text.AlignHCenter
+                                        color: Theme.highlightColor
+                                        anchors.left: parent.left
+                                        anchors.verticalCenter: keyLabel.verticalCenter
+                                    }
+                                    Rectangle {
+                                        color: 'transparent'
+                                        border.color: Theme.highlightColor
+                                        border.width: 2
+                                        anchors.fill: keyLabel
+                                        radius: Theme.paddingSmall
+                                    }
+                                    Label {
+                                        id: keyLabel
+                                        text: ' '+key+' '
+                                        horizontalAlignment: Text.AlignHCenter
+                                        color: Theme.highlightColor
+                                        anchors.left: plusLabel.right
+                                        anchors.top: parent.top
+
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                Label {
+                    id: commandLabel
+                    color: Theme.highlightColor
+                    width: parent.width - keyColumn.width
+                    text: descr
+                }
+            }
+            Separator {
+                width: parent.width
+            }
+        }
+    }
+    Component.onCompleted: readCommands()
+}

--- a/qml/pages/KeyboardOverviewPage.qml
+++ b/qml/pages/KeyboardOverviewPage.qml
@@ -115,7 +115,6 @@ Page {
                                         color: Theme.highlightColor
                                         anchors.left: plusLabel.right
                                         anchors.top: parent.top
-
                                     }
                                 }
                             }

--- a/qml/pages/KeyboardOverviewPage.qml
+++ b/qml/pages/KeyboardOverviewPage.qml
@@ -20,16 +20,17 @@ Page {
         for(var keySettingsIndex = 0; keySettingsIndex < keyboardCommands.keyboardSettings.length; keySettingsIndex++) {
             commandEntry = keyboardCommands.keyboardSettings[keySettingsIndex];
             tmpKey = commandEntry.methods.join('|');
-
+            tmpObj[tmpKey] = tmpObj[tmpKey] || {
+                keys:[],
+                displayed: false,
+                methods: commandEntry.methods,
+                descr: commandEntry.methods.map(function(methodName){
+                    return keyboardCommands.keyCommandsOverview[methodName].text
+                }).join('<br>')
+            }
+            tmpObj[tmpKey].keys.push({ key: commandEntry.key, modifiers: commandEntry.modifiers, combination: commandEntry.readableKeys.map(function(readableKey){return {key: readableKey};})})
             if(commandEntry.readableKeys && commandEntry.readableKeys.length > 0) {
-                tmpObj[tmpKey] = tmpObj[tmpKey] || {
-                    keys:[],
-                    methods: commandEntry.methods,
-                    descr: commandEntry.methods.map(function(methodName){
-                        return keyboardCommands.keyCommandsOverview[methodName].text
-                    }).join('<br>')
-                }
-                tmpObj[tmpKey].keys.push({combination: commandEntry.readableKeys.map(function(readableKey){return {key: readableKey};})})
+                tmpObj[tmpKey].displayed = true;
             }
         }
         /* fill model */
@@ -43,6 +44,18 @@ Page {
         target: keyboardCommands
         onStateChanged: readCommands()
     }
+    Item {
+        id: previewKeyHandlerItem
+        anchors.fill: parent
+        focus: true
+        signal keysPressed(int key, int modifiers)
+        Keys.onPressed: {
+            previewKeyHandlerItem.keysPressed(event.key, event.modifiers)
+        }
+    }
+
+
+
     PageHeader {
         id: pageHeader
         title: qsTr('Current Keyboard Shortcuts')
@@ -60,76 +73,124 @@ Page {
         horizontalAlignment: Text.AlignRight
         color: Theme.secondaryHighlightColor
         text: keyboardPage.isBB10
-              ? qsTr('You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.')
-              : qsTr('You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.')
+              ? qsTr('You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.')
+              : qsTr('You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.')
     }
     SilicaListView {
+        id: currentShortcutsList
         clip: true
         width: parent.width
         anchors.top: headerLabel.bottom
         anchors.bottom: parent.bottom
         model: currentShortcutsModel
-        delegate: Column {
+        delegate: Item {
+            id: keyCommandItem
             width: keyboardPage.width
-            Row {
-                width: parent.width - Theme.horizontalPageMargin * 2
-                x: Theme.horizontalPageMargin
-                height: Math.max(keyColumn.height, commandLabel.height) + Theme.paddingMedium * 2
-                Column {
-                    id: keyColumn
-                    width: Theme.itemSizeExtraLarge * 2
-                    spacing: Theme.paddingMedium
-                    y: Theme.paddingMedium
+            height: visible ? keyCommandColumn.height : 0
 
-                    Repeater {
-                        model: keys
-                        delegate: Flow {
-                            width: keyColumn.width
-                            Repeater {
-                                model: combination
-                                delegate: Item {
-                                    width: plusLabel.width + keyLabel.width
-                                    height: keyLabel.height
-                                    Label {
-                                        id: plusLabel
-                                        text: '+'
-                                        visible: index > 0
-                                        width: visible ? implicitWidth : 0
-                                        horizontalAlignment: Text.AlignHCenter
-                                        color: Theme.highlightColor
-                                        anchors.left: parent.left
-                                        anchors.verticalCenter: keyLabel.verticalCenter
-                                    }
-                                    Rectangle {
-                                        color: 'transparent'
-                                        border.color: Theme.highlightColor
-                                        border.width: 2
-                                        anchors.fill: keyLabel
-                                        radius: Theme.paddingSmall
-                                    }
-                                    Label {
-                                        id: keyLabel
-                                        text: ' '+key+' '
-                                        horizontalAlignment: Text.AlignHCenter
-                                        color: Theme.highlightColor
-                                        anchors.left: plusLabel.right
-                                        anchors.top: parent.top
+            visible: displayed
+            Rectangle {
+                anchors.fill: parent
+                color: Theme.rgba(Theme.highlightBackgroundColor, Theme.highlightBackgroundOpacity)
+                opacity: combinationHighlightTimer.running ? 1 : 0
+
+                Behavior on opacity {
+                    NumberAnimation { duration: 300 }
+                }
+            }
+            Column {
+                id: keyCommandColumn
+                width: keyboardPage.width
+                property color currentColor: combinationHighlightTimer.running ? Theme.primaryColor : Theme.highlightColor
+                Behavior on currentColor {
+                    ColorAnimation { duration: 300 }
+                }
+                Timer {
+                    id: combinationHighlightTimer
+                    interval: 1000
+                    onRunningChanged: {
+                        if(running){
+                            currentShortcutsList.positionViewAtIndex(index, ListView.Visible)
+                        }
+                    }
+                }
+
+                Row {
+                    id: keyCombinationRow
+                    width: parent.width - Theme.horizontalPageMargin * 2
+                    x: Theme.horizontalPageMargin
+                    height: Math.max(keyColumn.height, commandLabel.height) + Theme.paddingMedium * 2
+
+                    Column {
+                        id: keyColumn
+                        width: Theme.itemSizeExtraLarge * 2
+                        spacing: Theme.paddingMedium
+                        y: Theme.paddingMedium
+
+                        Repeater {
+                            model: keys
+                            delegate: Flow {
+                                width: keyColumn.width
+
+                                property int _key: key
+                                property int _modifiers: modifiers
+                                Component.onCompleted: {
+
+                                    previewKeyHandlerItem.keysPressed.connect(function(key, modifiers){
+                                        if(key === _key && modifiers === _modifiers && keyCommandColumn.visible) {
+                                            combinationHighlightTimer.start()
+                                        }
+                                    })
+
+                                }
+                                Repeater {
+                                    model: combination
+                                    delegate: Item {
+
+
+                                        width: plusLabel.width + keyLabel.width
+                                        height: keyLabel.height
+                                        Label {
+                                            id: plusLabel
+                                            text: '+'
+                                            visible: index > 0
+                                            width: visible ? implicitWidth : 0
+                                            horizontalAlignment: Text.AlignHCenter
+                                            color: keyCommandColumn.currentColor
+                                            anchors.left: parent.left
+                                            anchors.verticalCenter: keyLabel.verticalCenter
+                                        }
+                                        Rectangle {
+                                            color: 'transparent'
+                                            border.color: keyCommandColumn.currentColor
+                                            border.width: 2
+                                            anchors.fill: keyLabel
+                                            radius: Theme.paddingSmall
+                                        }
+                                        Label {
+                                            id: keyLabel
+                                            text: ' '+key+' '
+                                            horizontalAlignment: Text.AlignHCenter
+                                            color: keyCommandColumn.currentColor
+                                            anchors.left: plusLabel.right
+                                            anchors.top: parent.top
+                                        }
                                     }
                                 }
                             }
                         }
                     }
+                    Label {
+                        id: commandLabel
+                        color: keyCommandColumn.currentColor
+                        width: parent.width - keyColumn.width
+                        wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+                        text: descr
+                    }
                 }
-                Label {
-                    id: commandLabel
-                    color: Theme.highlightColor
-                    width: parent.width - keyColumn.width
-                    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
-                    text: descr
+                Separator {
+                    width: parent.width
                 }
-            }
-            Separator {
-                width: parent.width
             }
         }
     }

--- a/qml/pages/KeyboardOverviewPage.qml
+++ b/qml/pages/KeyboardOverviewPage.qml
@@ -36,7 +36,6 @@ Page {
         var tmpObjKeys = Object.keys(tmpObj);
         currentShortcutsModel.clear();
         for(var i = 0; i<tmpObjKeys.length;i++) {
-            console.log('append', i, JSON.stringify(tmpObj[tmpObjKeys[i]]))
             currentShortcutsModel.append(tmpObj[tmpObjKeys[i]]);
         }
     }

--- a/qml/pages/KeyboardOverviewPage.qml
+++ b/qml/pages/KeyboardOverviewPage.qml
@@ -126,6 +126,7 @@ Page {
                     id: commandLabel
                     color: Theme.highlightColor
                     width: parent.width - keyColumn.width
+                    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                     text: descr
                 }
             }

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -37,6 +37,7 @@ Dialog {
         searchEngineCombo.value = "Google"
         orientationCombo.value = "Orientation.All"
         vPlayerExternalSwitch.checked = false;
+        useBB10KeyboardShortcutsSwitch.checked = true;
     }
 
     function saveSettings() {
@@ -48,6 +49,7 @@ Dialog {
         DB.addSetting("loadImages", loadImagesSwitch.checked.toString());
         DB.addSetting("privateBrowsing", privateBrowsingSwitch.checked.toString());
         DB.addSetting("dnsPrefetch", dnsPrefetchSwitch.checked.toString());
+        DB.addSetting("useBB10KeyboardShortcuts", useBB10KeyboardShortcutsSwitch.checked.toString());
         DB.addSetting("userAgent", agentString.text);
         DB.addSetting("offlineWebApplicationCache", offlineWebApplicationCacheSwitch.checked.toString());
         if (userAgentCombo.value == qsTr("Custom")) DB.addSetting("userAgentName", "Custom");
@@ -391,6 +393,24 @@ Dialog {
                 menu: ContextMenu {
                     MenuItem { text: qsTr("New Tab | Stop/Refresh") }
                     MenuItem { text: qsTr("Previous Tab | Next Tab") }
+                }
+            }
+            Row {
+                width: parent.width
+                height: useBB10KeyboardShortcutsSwitch.height
+                TextSwitch {
+                    id: useBB10KeyboardShortcutsSwitch
+                    width: parent.width - keyboardOverviewButton.width
+                    text: qsTr("BB10 Hardware Keyboard shortcuts")
+                    description: qsTr("When unchecked, common multi-key shortcuts from other browsers are used")
+                    checked: mainWindow.useBB10KeyboardShortcuts
+                }
+                IconButton {
+                    id: keyboardOverviewButton
+                    width: Theme.itemSizeMedium
+                    height: Theme.itemSizeMedium
+                    icon.source: 'image://theme/icon-m-keyboard'
+                    onClicked: pageStack.push(Qt.resolvedUrl("KeyboardOverviewPage.qml"), {isBB10:useBB10KeyboardShortcutsSwitch.checked})
                 }
             }
 //            BackgroundItem {

--- a/qml/pages/helper/browserComponents/ExtraToolbar.qml
+++ b/qml/pages/helper/browserComponents/ExtraToolbar.qml
@@ -197,7 +197,11 @@ Rectangle {
         onClicked: {
             searchMode = !searchMode
             highlighted = false
-            searchText.forceActiveFocus();
+            if(searchMode) {
+                searchText.forceActiveFocus();
+            } else {
+                page.webview.forceActiveFocus();
+            }
             extraToolbar.hide();
         }
     }

--- a/qml/pages/helper/browserComponents/KeyboardCommands.qml
+++ b/qml/pages/helper/browserComponents/KeyboardCommands.qml
@@ -40,7 +40,7 @@ Item {
                                         { key: Qt.Key_W, modifiers: Qt.NoModifier,
                                             methods:['openNewTab'], readableKeys:['W']},
                                         { key: Qt.Key_T, modifiers: Qt.ControlModifier,
-                                            methods:['openNewTab'], readableKeys:[qsTr('Ctrl', 'Key'),'B']},
+                                            methods:['openNewTab'], readableKeys:[qsTr('Ctrl', 'Key'),'T']},
                                         { key: Qt.Key_W, modifiers: Qt.ShiftModifier,
                                             methods:['openNewWindow'], readableKeys:[qsTr('Shift', 'Key'),'W']},
                                         { key: Qt.Key_N, modifiers: Qt.ControlModifier,
@@ -54,6 +54,10 @@ Item {
                                         { key: Qt.Key_Backtab, modifiers: Qt.ControlModifier + Qt.ShiftModifier,
                                             requirements: mainWindow.tabModel.count > 1,
                                             methods:['focusPreviousTab'], readableKeys:[qsTr('Ctrl', 'Key'),qsTr('Shift', 'Key'), qsTr('Tab', 'Key')]},
+                                        //TOHKBD2 compatibility (does not send ctrl AND shift) but is quite safe for Key_Backtab:
+                                        { key: Qt.Key_Backtab, modifiers: Qt.ShiftModifier,
+                                            requirements: mainWindow.tabModel.count > 1,
+                                            methods:['focusPreviousTab'], readableKeys:[]},
                                         //no private window shortcut in bb10
 
                                         /* in-page search */
@@ -117,6 +121,10 @@ Item {
                                            { key: Qt.Key_Backtab, modifiers: Qt.ControlModifier + Qt.ShiftModifier,
                                                requirements: mainWindow.tabModel.count > 1,
                                                methods:['focusPreviousTab'], readableKeys:[qsTr('Ctrl', 'Key'),qsTr('Shift', 'Key'),qsTr('Tab', 'Key')]},
+                                           //TOHKBD2 compatibility (does not send ctrl AND shift) but is quite safe for Key_Backtab:
+                                           { key: Qt.Key_Backtab, modifiers: Qt.ShiftModifier,
+                                               requirements: mainWindow.tabModel.count > 1,
+                                               methods:['focusPreviousTab'], readableKeys:[]},
                                            // firefox variant
                                            { key: Qt.Key_P, modifiers: Qt.ControlModifier,
                                                methods:['openPrivateNewWindow'], readableKeys:[qsTr('Ctrl', 'Key'),'P']},
@@ -200,7 +208,6 @@ Item {
                 for(var methodsIndex=0;methodsIndex < keyboardSettings[i].methods.length; methodsIndex++) {
                     keyCommandsOverview[keyboardSettings[i].methods[methodsIndex]].method();
                 }
-
                 event.accepted = true;
                 debounceTimer.start()
                 break;

--- a/qml/pages/helper/browserComponents/KeyboardCommands.qml
+++ b/qml/pages/helper/browserComponents/KeyboardCommands.qml
@@ -26,7 +26,7 @@ Item {
                                         { key: Qt.Key_N, modifiers: Qt.NoModifier,
                                             methods:['goForward'], readableKeys:['N']},
                                         { key: Qt.Key_Escape, modifiers: Qt.NoModifier,
-                                            methods:['stopLoading', 'hideSearchBar'], readableKeys:[qsTr('Esc', 'Key')]},
+                                            methods:['stopLoading', 'hideSearchBar', 'hideBookmarks'], readableKeys:[qsTr('Esc', 'Key')]},
 
                                         /* bookmarks */
                                         { key: Qt.Key_A, modifiers: Qt.NoModifier,
@@ -92,7 +92,7 @@ Item {
                                            { key: Qt.Key_Right, modifiers: Qt.AltModifier,
                                                methods:['goForward'], readableKeys:[qsTr('Alt', 'Key'),'→']},
                                            { key: Qt.Key_Escape, modifiers: Qt.NoModifier,
-                                               methods:['stopLoading', 'hideSearchBar'], readableKeys:[qsTr('Esc', 'Key')]},
+                                               methods:['stopLoading', 'hideSearchBar', 'hideBookmarks'], readableKeys:[qsTr('Esc', 'Key')]},
 
                                            /* bookmarks */
                                            { key: Qt.Key_D, modifiers: Qt.ControlModifier,
@@ -161,6 +161,12 @@ Item {
                                            // bookmarks
                                            addBookmark: {text:qsTr("Add current website as a bookmark"), method:function(){toolbar.bookmarkButton.addFavorite()}},
                                            showBookmarks: {text:qsTr("Show list of bookmarks"), method:function(){ toolbar.gotoButton.clicked(undefined)}},
+                                           hideBookmarks: {text:qsTr("Hide list of bookmarks"), method:function(){
+                                               if (page.tabBar._tabListBg.visible) {
+                                                   toolbar.gotoButton.clicked(undefined)
+                                               }
+                                           }
+                                           },
 
                                            // tabs/windows
                                            openNewTab: {text:qsTr("Open new tab"), method:function(){ mainWindow.loadInNewTab("about:bookmarks");}},

--- a/qml/pages/helper/browserComponents/KeyboardCommands.qml
+++ b/qml/pages/helper/browserComponents/KeyboardCommands.qml
@@ -194,14 +194,6 @@ Item {
         }
 
         for (var i=0; i<keyboardSettings.length; i++) {
-            if(event.key === keyboardSettings[i].key) {
-                console.log('at least key matches',
-                            keyboardSettings[i].methods.join('|'),
-                            event.modifiers,
-                            keyboardSettings[i].modifiers,
-                            'b:', keyboardSettings[i].requirements)
-            }
-
             if(event.key === keyboardSettings[i].key
                     && (typeof keyboardSettings[i].modifiers !== 'undefined' ? event.modifiers === keyboardSettings[i].modifiers : true)
                     && (typeof keyboardSettings[i].requirements !== 'undefined' ? keyboardSettings[i].requirements : true)) {

--- a/qml/pages/helper/browserComponents/KeyboardCommands.qml
+++ b/qml/pages/helper/browserComponents/KeyboardCommands.qml
@@ -1,0 +1,216 @@
+import QtQuick 2.0
+
+Item {
+    id: keyboardRoot
+    property alias debounceMilliseconds: debounceTimer.interval
+    //overwriteable for preview page
+    property bool isBB10: mainWindow.useBB10KeyboardShortcuts
+    StateGroup {
+        state: "BB10"
+        states: [
+            State {
+                name: "BB10" //default BB10 style keyboard commands
+                when: keyboardRoot.isBB10
+                PropertyChanges {
+                    target: keyboardRoot
+                    keyboardSettings: ([
+                                        /* scrolling / page navigation */
+                                        { key: Qt.Key_B, modifiers: Qt.NoModifier,
+                                            methods:['scrollToBottom'], readableKeys:['B']},
+                                        { key: Qt.Key_T, modifiers: Qt.NoModifier,
+                                            methods:['scrollToTop'], readableKeys:['T']},
+                                        { key: Qt.Key_L, modifiers: Qt.NoModifier,
+                                            methods:['reloadWebView'], readableKeys:['L']},
+                                        { key: Qt.Key_P, modifiers: Qt.NoModifier,
+                                            methods:['goBack'], readableKeys:['P']},
+                                        { key: Qt.Key_N, modifiers: Qt.NoModifier,
+                                            methods:['goForward'], readableKeys:['N']},
+                                        { key: Qt.Key_Escape, modifiers: Qt.NoModifier,
+                                            methods:['stopLoading', 'hideSearchBar'], readableKeys:[qsTr('Esc', 'Key')]},
+
+                                        /* bookmarks */
+                                        { key: Qt.Key_A, modifiers: Qt.NoModifier,
+                                            methods:['addBookmark'], readableKeys:['A']},
+                                        { key: Qt.Key_K, modifiers: Qt.NoModifier,
+                                            methods:['showBookmarks'], readableKeys:['K']},
+                                        { key: Qt.Key_Q, modifiers: Qt.NoModifier,
+                                            methods:['showBookmarks'], readableKeys:['Q']},
+
+                                        /* tabs/windows */
+                                        { key: Qt.Key_W, modifiers: Qt.NoModifier,
+                                            methods:['openNewTab'], readableKeys:['W']},
+                                        { key: Qt.Key_T, modifiers: Qt.ControlModifier,
+                                            methods:['openNewTab'], readableKeys:[qsTr('Ctrl', 'Key'),'B']},
+                                        { key: Qt.Key_W, modifiers: Qt.ShiftModifier,
+                                            methods:['openNewWindow'], readableKeys:[qsTr('Shift', 'Key'),'W']},
+                                        { key: Qt.Key_N, modifiers: Qt.ControlModifier,
+                                            methods:['openNewWindow'], readableKeys:[qsTr('Ctrl', 'Key'),'N']},
+                                        { key: Qt.Key_W, modifiers: Qt.ControlModifier,
+                                            requirements: mainWindow.tabModel.count > 1,
+                                            methods:['closeCurrentTab'], readableKeys:[qsTr('Ctrl', 'Key'),'W']},
+                                        { key: Qt.Key_Tab, modifiers: Qt.ControlModifier,
+                                            requirements: mainWindow.tabModel.count > 1,
+                                            methods:['focusNextTab'], readableKeys:[qsTr('Ctrl', 'Key'),qsTr('Tab', 'Key')]},
+                                        { key: Qt.Key_Backtab, modifiers: Qt.ControlModifier + Qt.ShiftModifier,
+                                            requirements: mainWindow.tabModel.count > 1,
+                                            methods:['focusPreviousTab'], readableKeys:[qsTr('Ctrl', 'Key'),qsTr('Shift', 'Key'), qsTr('Tab', 'Key')]},
+                                        //no private window shortcut in bb10
+
+                                        /* in-page search */
+                                        { key: Qt.Key_S, modifiers: Qt.NoModifier,
+                                            methods:['showSearchBar'], readableKeys:['S']},
+                                        { key: Qt.Key_Enter, modifiers: Qt.NoModifier,
+                                            requirements:  typeof searchBar !== 'undefined' && searchBar.visible,
+                                            methods:['submitSearchBar'], readableKeys:[]},
+                                        { key: Qt.Key_Return, modifiers: Qt.NoModifier,
+                                            requirements:  typeof searchBar !== 'undefined' && searchBar.visible,
+                                            methods:['submitSearchBar'], readableKeys:[]},
+
+                                        /* misc */
+                                        { key: Qt.Key_R, modifiers: Qt.NoModifier,
+                                            methods:['toggleReaderMode'], readableKeys:['R']},
+                                        { key: Qt.Key_U, modifiers: Qt.NoModifier,
+                                            methods:['focusUrlBar'], readableKeys:['U']}
+                                       ])
+                }
+            },
+            State {
+                name: "Ffx"
+                when: !keyboardRoot.isBB10
+                PropertyChanges {
+                    target: keyboardRoot
+                    keyboardSettings: ([
+                                           /* scrolling / page navigation */
+                                           { key: Qt.Key_End, modifiers: Qt.NoModifier,
+                                               methods:['scrollToBottom'], readableKeys:[qsTr('End', 'Key')]},
+                                           { key: Qt.Key_Home, modifiers: Qt.NoModifier,
+                                               methods:['scrollToTop'], readableKeys:[qsTr('Home', 'Key')]},
+                                           { key: Qt.Key_R, modifiers: Qt.ControlModifier,
+                                               methods:['reloadWebView'], readableKeys:[qsTr('Ctrl', 'Key'),'R']},
+                                           { key: Qt.Key_Left, modifiers: Qt.AltModifier,
+                                               methods:['goBack'], readableKeys:[qsTr('Alt', 'Key'),'←']},
+                                           { key: Qt.Key_Right, modifiers: Qt.AltModifier,
+                                               methods:['goForward'], readableKeys:[qsTr('Alt', 'Key'),'→']},
+                                           { key: Qt.Key_Escape, modifiers: Qt.NoModifier,
+                                               methods:['stopLoading', 'hideSearchBar'], readableKeys:[qsTr('Esc', 'Key')]},
+
+                                           /* bookmarks */
+                                           { key: Qt.Key_D, modifiers: Qt.ControlModifier,
+                                               methods:['addBookmark'], readableKeys:[qsTr('Ctrl', 'Key'),'D']},
+                                           // firefox "bookmarks sidebar"
+                                           { key: Qt.Key_B, modifiers: Qt.ControlModifier,
+                                               methods:['showBookmarks'], readableKeys:[qsTr('Ctrl', 'Key'),'B']},
+                                           { key: Qt.Key_O, modifiers: Qt.ControlModifier + Qt.ShiftModifier,
+                                               methods:['showBookmarks'], readableKeys:[qsTr('Ctrl', 'Key'),qsTr('Shift', 'Key'),'O']},
+
+                                           /* tabs/windows */
+                                           { key: Qt.Key_T, modifiers: Qt.ControlModifier,
+                                               methods:['openNewTab'], readableKeys:[qsTr('Ctrl', 'Key'),'T']},
+                                           { key: Qt.Key_N, modifiers: Qt.ControlModifier,
+                                               methods:['openNewWindow'], readableKeys:[qsTr('Ctrl', 'Key'),'N']},
+                                           { key: Qt.Key_W, modifiers: Qt.ControlModifier,
+                                               requirements: mainWindow.tabModel.count > 1,
+                                               methods:['closeCurrentTab'], readableKeys:[qsTr('Ctrl', 'Key'),'W']},
+                                           { key: Qt.Key_Tab, modifiers: Qt.ControlModifier,
+                                               requirements: mainWindow.tabModel.count > 1,
+                                               methods:['focusNextTab'], readableKeys:[qsTr('Ctrl', 'Key'),qsTr('Tab', 'Key')]},
+                                           { key: Qt.Key_Backtab, modifiers: Qt.ControlModifier + Qt.ShiftModifier,
+                                               requirements: mainWindow.tabModel.count > 1,
+                                               methods:['focusPreviousTab'], readableKeys:[qsTr('Ctrl', 'Key'),qsTr('Shift', 'Key'),qsTr('Tab', 'Key')]},
+                                           // firefox variant
+                                           { key: Qt.Key_P, modifiers: Qt.ControlModifier,
+                                               methods:['openPrivateNewWindow'], readableKeys:[qsTr('Ctrl', 'Key'),'P']},
+                                           // chrome variant
+                                           { key: Qt.Key_N, modifiers: Qt.ControlModifier + Qt.ShiftModifier,
+                                               methods:['openPrivateNewWindow'], readableKeys:[qsTr('Ctrl', 'Key'),qsTr('Shift', 'Key'),'N']},
+
+                                           /* in-page search */
+                                           { key: Qt.Key_F, modifiers: Qt.ControlModifier,
+                                               methods:['showSearchBar'], readableKeys:[qsTr('Ctrl', 'Key'),'F']},
+                                           { key: Qt.Key_Enter, modifiers: Qt.NoModifier,
+                                               requirements:  typeof searchBar !== 'undefined' && searchBar.visible,
+                                               methods:['submitSearchBar'], readableKeys:[]},
+                                           { key: Qt.Key_Return, modifiers: Qt.NoModifier,
+                                               requirements:  typeof searchBar !== 'undefined' && searchBar.visible,
+                                               methods:['submitSearchBar'], readableKeys:[]},
+
+                                           /* misc */
+                                           { key: Qt.Key_R, modifiers: Qt.ControlModifier + Qt.AltModifier,
+                                               methods:['toggleReaderMode'], readableKeys:[qsTr('Ctrl', 'Key'),qsTr('Alt', 'Key'),'R']},
+                                           { key: Qt.Key_D, modifiers: Qt.AltModifier,
+                                               methods:['focusUrlBar'], readableKeys:[qsTr('Alt', 'Key'),'D']},
+                                           { key: Qt.Key_L, modifiers: Qt.ControlModifier,
+                                               methods:['focusUrlBar'], readableKeys:[qsTr('Ctrl', 'Key'),'L']},
+                                           { key: Qt.Key_Q, modifiers: Qt.ControlModifier,
+                                               methods:['exit'], readableKeys:[qsTr('Ctrl', 'Key'),'Q']}
+                                       ])
+                }
+            }
+
+        ]
+    }
+    property var keyCommandsOverview: ({
+                                           // scrolling / page navigation
+                                           scrollToBottom: {text:qsTr("Scroll current website to bottom"), method:function(){ webview.scrollToBottom()}},
+                                           scrollToTop: {text:qsTr("Scroll current website to top"), method:function(){ webview.scrollToTop()}},
+                                           reloadWebView: {text:qsTr("Reload current website"), method:function(){ webview.reload()}},
+                                           goBack: {text:qsTr("Page History: Go back"), method:function(){webview.goBack()}},
+                                           goForward: {text:qsTr("Page History: Go forward"), method:function(){webview.goForward()}},
+                                           stopLoading: {text:qsTr("Stop loading the current website"), method:function(){webview.stop();}},
+
+                                           // bookmarks
+                                           addBookmark: {text:qsTr("Add current website as a bookmark"), method:function(){toolbar.bookmarkButton.addFavorite()}},
+                                           showBookmarks: {text:qsTr("Show list of bookmarks"), method:function(){ toolbar.gotoButton.clicked(undefined)}},
+
+                                           // tabs/windows
+                                           openNewTab: {text:qsTr("Open new tab"), method:function(){ mainWindow.loadInNewTab("about:bookmarks");}},
+                                           openNewWindow: {text:qsTr("Open new window"), method:function(){ mainWindow.openNewWindow("about:bookmarks")}},
+                                           closeCurrentTab: {text:qsTr("Close current tab"), method:function(){ mainWindow.closeTab(mainWindow.tabModel.getIndexFromId(mainWindow.currentTab),mainWindow.currentTab)}},
+                                           focusNextTab: {text:qsTr("Switch to next tab"), method:function(){ mainWindow.switchToTab(mainWindow.tabModel.get(mainWindow.tabModel.nextTab()).pageid)}},
+                                           focusPreviousTab: {text:qsTr("Switch to previous tab"), method:function(){mainWindow.switchToTab(mainWindow.tabModel.get(mainWindow.tabModel.prevTab()).pageid)}},
+                                           openPrivateNewWindow: {text:qsTr("Open new private window"), method:function(){mainWindow.openPrivateNewWindow("http://about:blank")}},
+
+                                           // in-page search
+                                           showSearchBar: {text:qsTr("Show in-page search"), method:function(){ extraToolbar.searchModeButton.clicked(undefined)}},
+                                           hideSearchBar: {text:qsTr("Hide in-page search"), method:function(){ page.searchMode = false}},
+                                           submitSearchBar: {text:qsTr("Start in-page search"), method:function(){ searchIcon.clicked(undefined)}},
+
+                                           // misc
+                                           toggleReaderMode: {text:qsTr("Toggle reader mode"), method:function(){ extraToolbar.readerModeButton.clicked(undefined)}},
+                                           focusUrlBar: {text:qsTr("Focus URL bar"), method:function(){ toolbar.state = "expanded"; toolbar.urlText.forceActiveFocus()}},
+                                           exit: {text:qsTr("Close current WebCat window"), method:function(){ Qt.quit()}},
+
+                                       })
+    property var keyboardSettings:([]) //overridden in state
+    function handleKeyPress(event) {
+        if(debounceTimer.running) {
+            return;
+        }
+
+        for (var i=0; i<keyboardSettings.length; i++) {
+            if(event.key === keyboardSettings[i].key) {
+                console.log('at least key matches',
+                            keyboardSettings[i].methods.join('|'),
+                            event.modifiers,
+                            keyboardSettings[i].modifiers,
+                            'b:', keyboardSettings[i].requirements)
+            }
+
+            if(event.key === keyboardSettings[i].key
+                    && (typeof keyboardSettings[i].modifiers !== 'undefined' ? event.modifiers === keyboardSettings[i].modifiers : true)
+                    && (typeof keyboardSettings[i].requirements !== 'undefined' ? keyboardSettings[i].requirements : true)) {
+                for(var methodsIndex=0;methodsIndex < keyboardSettings[i].methods.length; methodsIndex++) {
+                    keyCommandsOverview[keyboardSettings[i].methods[methodsIndex]].method();
+                }
+
+                event.accepted = true;
+                debounceTimer.start()
+                break;
+            }
+        }
+    }
+    Timer {
+        id: debounceTimer
+        interval: 600
+    }
+}

--- a/qml/pages/helper/browserComponents/Toolbar.qml
+++ b/qml/pages/helper/browserComponents/Toolbar.qml
@@ -508,9 +508,17 @@ Rectangle {
                 fPage.suggestionView.visible = false;
             }
         }
-
-        Keys.onEnterPressed: {
+        function enterPress(event){
             if (fPage.suggestionView.visible) fPage.suggestionView.visible = false;
+
+            if(event.modifiers === Qt.ControlModifier) {
+                urlText.text = urlText.text + '.com'
+            } else if(event.modifiers === Qt.ShiftModifier) {
+                urlText.text = urlText.text + '.net'
+            } else if(event.modifiers === Qt.ControlModifier + Qt.ShiftModifier) {
+                urlText.text = urlText.text + '.org'
+            }
+
             fPage.webview.url = fixUrl(urlText.text);
             urlText.focus = false;  // Close keyboard
             fPage.webview.focus = true;
@@ -520,18 +528,8 @@ Rectangle {
             }
             urlTitle.visible = false
         }
-
-        Keys.onReturnPressed: {
-            if (fPage.suggestionView.visible) fPage.suggestionView.visible = false;
-            fPage.webview.url = fixUrl(urlText.text);
-            urlText.focus = false;
-            fPage.webview.focus = true;
-            if (bookmarkList.visible || tabBar.visible) {
-                bookmarkList.hide()
-                tabBar.hide()
-            }
-            urlTitle.visible = false
-        }
+        Keys.onEnterPressed: enterPress(event)
+        Keys.onReturnPressed: enterPress(event)
         function simplifyUrl(url) {
             url = url.toString();
             if(url.match(/http:\/\//))

--- a/qml/pages/helper/browserComponents/Toolbar.qml
+++ b/qml/pages/helper/browserComponents/Toolbar.qml
@@ -548,6 +548,10 @@ Rectangle {
             }
             return url;
         }
+
+        Keys.onEscapePressed: {
+            fPage.webview.focus = true
+        }
     }
 
 

--- a/qml/pages/helper/db.js
+++ b/qml/pages/helper/db.js
@@ -190,6 +190,7 @@ function getSettings() {
             else if (rs.rows.item(i).setting == "vPlayerExternal") mainWindow.vPlayerExternal = stringToBoolean(rs.rows.item(i).value)
             else if (rs.rows.item(i).setting == "coverActionGroup") mainWindow.coverActionGroup = parseInt(rs.rows.item(i).value)
             else if (rs.rows.item(i).setting == "torProxyEnabled") mainWindow.torProxyEnabled = stringToBoolean(rs.rows.item(i).value)
+            else if (rs.rows.item(i).setting == "useBB10KeyboardShortcuts") mainWindow.useBB10KeyboardShortcuts = stringToBoolean(rs.rows.item(i).value)
         }
     })
 }

--- a/translations/harbour-webcat-ca.ts
+++ b/translations/harbour-webcat-ca.ts
@@ -449,6 +449,46 @@ En cas de dubte, refuseu el certificat malgrat que això pot provocar que no es 
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
         <translation type="unfinished"></translation>
@@ -492,18 +532,6 @@ En cas de dubte, refuseu el certificat malgrat que això pot provocar que no es 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stop loading the current website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -516,31 +544,7 @@ En cas de dubte, refuseu el certificat malgrat que això pot provocar que no es 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -552,15 +556,15 @@ En cas de dubte, refuseu el certificat malgrat que això pot provocar que no es 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1040,11 +1044,11 @@ En cas de dubte, refuseu el certificat malgrat que això pot provocar que no es 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <source>BB10 Hardware Keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-ca.ts
+++ b/translations/harbour-webcat-ca.ts
@@ -579,11 +579,11 @@ En cas de dubte, refuseu el certificat malgrat que això pot provocar que no es 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-ca.ts
+++ b/translations/harbour-webcat-ca.ts
@@ -567,6 +567,10 @@ En cas de dubte, refuseu el certificat malgrat que això pot provocar que no es 
         <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat-ca.ts
+++ b/translations/harbour-webcat-ca.ts
@@ -447,6 +447,139 @@ En cas de dubte, refuseu el certificat malgrat que això pot provocar que no es 
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -904,6 +1037,14 @@ En cas de dubte, refuseu el certificat malgrat que això pot provocar que no es 
     </message>
     <message>
         <source>Engine URL use %s for searchterm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-cs.ts
+++ b/translations/harbour-webcat-cs.ts
@@ -446,6 +446,46 @@ If you are unsure reject the certificate. That might lead to a non loading websi
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
         <translation type="unfinished"></translation>
@@ -489,18 +529,6 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stop loading the current website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -513,31 +541,7 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -549,15 +553,15 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1036,11 +1040,11 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <source>BB10 Hardware Keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-cs.ts
+++ b/translations/harbour-webcat-cs.ts
@@ -576,11 +576,11 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-cs.ts
+++ b/translations/harbour-webcat-cs.ts
@@ -564,6 +564,10 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat-cs.ts
+++ b/translations/harbour-webcat-cs.ts
@@ -444,6 +444,139 @@ If you are unsure reject the certificate. That might lead to a non loading websi
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -900,6 +1033,14 @@ If you are unsure reject the certificate. That might lead to a non loading websi
     </message>
     <message>
         <source>Engine URL use %s for searchterm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-de.ts
+++ b/translations/harbour-webcat-de.ts
@@ -563,6 +563,10 @@ Wenn Sie sich unsicher sind lehnen sie das Zertifikat ab. Dies führt unter Umst
         <source>Show in-page search</source>
         <translation>Zeige &quot;Suche auf Seite&quot;</translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation>Verberge Bookmarks</translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat-de.ts
+++ b/translations/harbour-webcat-de.ts
@@ -447,6 +447,139 @@ Wenn Sie sich unsicher sind lehnen sie das Zertifikat ab. Dies führt unter Umst
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished">Benutzerverzeichnis</translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -904,6 +1037,14 @@ Wenn Sie sich unsicher sind lehnen sie das Zertifikat ab. Dies führt unter Umst
     <message>
         <source>Engine URL use %s for searchterm</source>
         <translation>Suchmaschinen URL eingeben %s für Suchbegriff</translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-webcat-de.ts
+++ b/translations/harbour-webcat-de.ts
@@ -449,134 +449,134 @@ Wenn Sie sich unsicher sind lehnen sie das Zertifikat ab. Dies führt unter Umst
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source>Reload current website</source>
+        <translation>Aktuelle Webseite neuladen</translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation>Navigiere eine Seite vor</translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation>Navigiere eine Seite zurück</translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation>Neuen Tab öffnen</translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation>Neues Fenster öffnen</translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation>Aktuellen Tab schließen</translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation>Zu nächstem Tab wechseln</translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation>Zu vorigem Tab wechseln</translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation>Lesemodus umschalten</translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation>URL-Leiste fokussieren</translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
-        <translation type="unfinished"></translation>
+        <translation>Esc</translation>
     </message>
     <message>
         <source>Ctrl</source>
         <comment>Key</comment>
-        <translation type="unfinished"></translation>
+        <translation>Strg</translation>
     </message>
     <message>
         <source>Shift</source>
         <comment>Key</comment>
-        <translation type="unfinished"></translation>
+        <translation>Umschalt</translation>
     </message>
     <message>
         <source>Tab</source>
         <comment>Key</comment>
-        <translation type="unfinished"></translation>
+        <translation>Tab</translation>
     </message>
     <message>
         <source>End</source>
         <comment>Key</comment>
-        <translation type="unfinished"></translation>
+        <translation>Ende</translation>
     </message>
     <message>
         <source>Home</source>
         <comment>Key</comment>
-        <translation type="unfinished">Benutzerverzeichnis</translation>
+        <translation>Pos1</translation>
     </message>
     <message>
         <source>Alt</source>
         <comment>Key</comment>
-        <translation type="unfinished"></translation>
+        <translation>Alt</translation>
     </message>
     <message>
         <source>Scroll current website to bottom</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktuelle Webseite komplett nach unten scrollen</translation>
     </message>
     <message>
         <source>Scroll current website to top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktuelle Webseite komplett nach oben scrollen</translation>
     </message>
     <message>
         <source>Stop loading the current website</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktuelles Seitenladen unterbrechen</translation>
     </message>
     <message>
         <source>Add current website as a bookmark</source>
-        <translation type="unfinished"></translation>
+        <translation>Füge aktuelle Webseite als Bookmark hinzu</translation>
     </message>
     <message>
         <source>Show list of bookmarks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeige Bookmarks</translation>
     </message>
     <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
-        <translation type="unfinished"></translation>
+        <translation>Öffne neues, privates Fenster</translation>
     </message>
     <message>
         <source>Hide in-page search</source>
-        <translation type="unfinished"></translation>
+        <translation>Blende &quot;Suche auf Seite&quot; aus</translation>
     </message>
     <message>
         <source>Start in-page search</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
+        <translation>Suche auf Seite</translation>
     </message>
     <message>
         <source>Close current WebCat window</source>
-        <translation type="unfinished"></translation>
+        <translation>Schließe aktuelles WebCatfenster</translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation>Zeige &quot;Suche auf Seite&quot;</translation>
     </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>
     <message>
         <source>Current Keyboard Shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktuelle Tastenkürzel</translation>
     </message>
     <message>
         <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
-        <translation type="unfinished"></translation>
+        <translation>Du hast BB10-kompatible (Blackberry 10) Tastenkürzel ausgewählt. Schau auf die folgende Liste, um zu sehen, welche es gibt.</translation>
     </message>
     <message>
         <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
-        <translation type="unfinished"></translation>
+        <translation>Du hast Tastenkürzel ausgewählt, die denen einiger populärer Browser entsprechen. Schau auf die folgende Liste, um zu sehen, welche es gibt.</translation>
     </message>
 </context>
 <context>
@@ -1039,12 +1039,12 @@ Wenn Sie sich unsicher sind lehnen sie das Zertifikat ab. Dies führt unter Umst
         <translation>Suchmaschinen URL eingeben %s für Suchbegriff</translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
-        <translation type="unfinished"></translation>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <translation>Wenn nicht angehakt, werden übliche Mehrtastenkürzel anderer Browser genutzt</translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
-        <translation type="unfinished"></translation>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation>BB10 Hardwaretastenkürzel</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-webcat-de.ts
+++ b/translations/harbour-webcat-de.ts
@@ -575,12 +575,12 @@ Wenn Sie sich unsicher sind lehnen sie das Zertifikat ab. Dies führt unter Umst
         <translation>Aktuelle Tastenkürzel</translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
-        <translation>Du hast BB10-kompatible (Blackberry 10) Tastenkürzel ausgewählt. Schau auf die folgende Liste, um zu sehen, welche es gibt.</translation>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
+        <translation>Du hast BB10-kompatible (Blackberry 10) Tastenkürzel ausgewählt. Schau auf die folgende Liste, um zu sehen, welche es gibt – oder probiere sie aus.</translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
-        <translation>Du hast Tastenkürzel ausgewählt, die denen einiger populärer Browser entsprechen. Schau auf die folgende Liste, um zu sehen, welche es gibt.</translation>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
+        <translation>Du hast Tastenkürzel ausgewählt, die denen einiger populärer Browser entsprechen. Schau auf die folgende Liste, um zu sehen, welche es gibt – oder probiere sie aus.</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-webcat-es.ts
+++ b/translations/harbour-webcat-es.ts
@@ -579,11 +579,11 @@ Si no estás seguro, rechaza el certificado. Esto podría hacer que la página n
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-es.ts
+++ b/translations/harbour-webcat-es.ts
@@ -449,6 +449,46 @@ Si no estás seguro, rechaza el certificado. Esto podría hacer que la página n
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
         <translation type="unfinished"></translation>
@@ -492,18 +532,6 @@ Si no estás seguro, rechaza el certificado. Esto podría hacer que la página n
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stop loading the current website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -516,31 +544,7 @@ Si no estás seguro, rechaza el certificado. Esto podría hacer que la página n
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -552,15 +556,15 @@ Si no estás seguro, rechaza el certificado. Esto podría hacer que la página n
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1040,11 +1044,11 @@ Si no estás seguro, rechaza el certificado. Esto podría hacer que la página n
         <translation>El motor URL usa %s como término de búsqueda</translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <source>BB10 Hardware Keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-es.ts
+++ b/translations/harbour-webcat-es.ts
@@ -447,6 +447,139 @@ Si no estás seguro, rechaza el certificado. Esto podría hacer que la página n
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished">Carpeta personal</translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -905,6 +1038,14 @@ Si no estás seguro, rechaza el certificado. Esto podría hacer que la página n
     <message>
         <source>Engine URL use %s for searchterm</source>
         <translation>El motor URL usa %s como término de búsqueda</translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-webcat-es.ts
+++ b/translations/harbour-webcat-es.ts
@@ -567,6 +567,10 @@ Si no estás seguro, rechaza el certificado. Esto podría hacer que la página n
         <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat-fi.ts
+++ b/translations/harbour-webcat-fi.ts
@@ -447,6 +447,46 @@ If you are unsure reject the certificate. That might lead to a non loading websi
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
         <translation type="unfinished"></translation>
@@ -490,18 +530,6 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stop loading the current website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -514,31 +542,7 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -550,15 +554,15 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1038,11 +1042,11 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <source>BB10 Hardware Keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-fi.ts
+++ b/translations/harbour-webcat-fi.ts
@@ -565,6 +565,10 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat-fi.ts
+++ b/translations/harbour-webcat-fi.ts
@@ -577,11 +577,11 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-fi.ts
+++ b/translations/harbour-webcat-fi.ts
@@ -445,6 +445,139 @@ If you are unsure reject the certificate. That might lead to a non loading websi
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -902,6 +1035,14 @@ If you are unsure reject the certificate. That might lead to a non loading websi
     </message>
     <message>
         <source>Engine URL use %s for searchterm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-fr.ts
+++ b/translations/harbour-webcat-fr.ts
@@ -448,6 +448,46 @@ Les certificats inconnus sont soit manquants dans la configuration de votre navi
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
         <translation type="unfinished"></translation>
@@ -491,18 +531,6 @@ Les certificats inconnus sont soit manquants dans la configuration de votre navi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stop loading the current website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -515,31 +543,7 @@ Les certificats inconnus sont soit manquants dans la configuration de votre navi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -551,15 +555,15 @@ Les certificats inconnus sont soit manquants dans la configuration de votre navi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1039,11 +1043,11 @@ Les certificats inconnus sont soit manquants dans la configuration de votre navi
         <translation>Le Moteur URL utilise %s comme terme de recherche</translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <source>BB10 Hardware Keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-fr.ts
+++ b/translations/harbour-webcat-fr.ts
@@ -578,11 +578,11 @@ Les certificats inconnus sont soit manquants dans la configuration de votre navi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-fr.ts
+++ b/translations/harbour-webcat-fr.ts
@@ -446,6 +446,139 @@ Les certificats inconnus sont soit manquants dans la configuration de votre navi
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished">Accueil</translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -904,6 +1037,14 @@ Les certificats inconnus sont soit manquants dans la configuration de votre navi
     <message>
         <source>Engine URL use %s for searchterm</source>
         <translation>Le Moteur URL utilise %s comme terme de recherche</translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-webcat-fr.ts
+++ b/translations/harbour-webcat-fr.ts
@@ -566,6 +566,10 @@ Les certificats inconnus sont soit manquants dans la configuration de votre navi
         <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat-it.ts
+++ b/translations/harbour-webcat-it.ts
@@ -567,6 +567,10 @@ Se non sei sicuro, rifiuta il certificato. Ma questo può impedire il caricament
         <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat-it.ts
+++ b/translations/harbour-webcat-it.ts
@@ -449,6 +449,46 @@ Se non sei sicuro, rifiuta il certificato. Ma questo può impedire il caricament
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
         <translation type="unfinished"></translation>
@@ -492,18 +532,6 @@ Se non sei sicuro, rifiuta il certificato. Ma questo può impedire il caricament
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stop loading the current website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -516,31 +544,7 @@ Se non sei sicuro, rifiuta il certificato. Ma questo può impedire il caricament
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -552,15 +556,15 @@ Se non sei sicuro, rifiuta il certificato. Ma questo può impedire il caricament
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1040,11 +1044,11 @@ Se non sei sicuro, rifiuta il certificato. Ma questo può impedire il caricament
         <translation>URL del Motore. %s vien sostituito dal termine di ricerca</translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <source>BB10 Hardware Keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-it.ts
+++ b/translations/harbour-webcat-it.ts
@@ -579,11 +579,11 @@ Se non sei sicuro, rifiuta il certificato. Ma questo può impedire il caricament
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-it.ts
+++ b/translations/harbour-webcat-it.ts
@@ -447,6 +447,139 @@ Se non sei sicuro, rifiuta il certificato. Ma questo può impedire il caricament
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished">Home</translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -905,6 +1038,14 @@ Se non sei sicuro, rifiuta il certificato. Ma questo può impedire il caricament
     <message>
         <source>Engine URL use %s for searchterm</source>
         <translation>URL del Motore. %s vien sostituito dal termine di ricerca</translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-webcat-nl_NL.ts
+++ b/translations/harbour-webcat-nl_NL.ts
@@ -579,11 +579,11 @@ Als je niet zeker bent, weiger dan het certificaat. Dit kan er wel toe leiden da
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-nl_NL.ts
+++ b/translations/harbour-webcat-nl_NL.ts
@@ -567,6 +567,10 @@ Als je niet zeker bent, weiger dan het certificaat. Dit kan er wel toe leiden da
         <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat-nl_NL.ts
+++ b/translations/harbour-webcat-nl_NL.ts
@@ -447,6 +447,139 @@ Als je niet zeker bent, weiger dan het certificaat. Dit kan er wel toe leiden da
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -905,6 +1038,14 @@ Als je niet zeker bent, weiger dan het certificaat. Dit kan er wel toe leiden da
     <message>
         <source>Engine URL use %s for searchterm</source>
         <translation>Zoekmachine-URL, gebruik %s waar de zoekterm moet komen</translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-webcat-nl_NL.ts
+++ b/translations/harbour-webcat-nl_NL.ts
@@ -449,6 +449,46 @@ Als je niet zeker bent, weiger dan het certificaat. Dit kan er wel toe leiden da
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
         <translation type="unfinished"></translation>
@@ -492,18 +532,6 @@ Als je niet zeker bent, weiger dan het certificaat. Dit kan er wel toe leiden da
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stop loading the current website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -516,31 +544,7 @@ Als je niet zeker bent, weiger dan het certificaat. Dit kan er wel toe leiden da
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -552,15 +556,15 @@ Als je niet zeker bent, weiger dan het certificaat. Dit kan er wel toe leiden da
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1040,11 +1044,11 @@ Als je niet zeker bent, weiger dan het certificaat. Dit kan er wel toe leiden da
         <translation>Zoekmachine-URL, gebruik %s waar de zoekterm moet komen</translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <source>BB10 Hardware Keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-pl.ts
+++ b/translations/harbour-webcat-pl.ts
@@ -448,6 +448,46 @@ Jeśli nie jesteś pewien, powinieneś odrzucić certyfikat. Może to jednak uni
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
         <translation type="unfinished"></translation>
@@ -491,18 +531,6 @@ Jeśli nie jesteś pewien, powinieneś odrzucić certyfikat. Może to jednak uni
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stop loading the current website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -515,31 +543,7 @@ Jeśli nie jesteś pewien, powinieneś odrzucić certyfikat. Może to jednak uni
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -551,15 +555,15 @@ Jeśli nie jesteś pewien, powinieneś odrzucić certyfikat. Może to jednak uni
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1039,11 +1043,11 @@ Jeśli nie jesteś pewien, powinieneś odrzucić certyfikat. Może to jednak uni
         <translation>Silnik URL używa %s do wyszukiwania</translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <source>BB10 Hardware Keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-pl.ts
+++ b/translations/harbour-webcat-pl.ts
@@ -446,6 +446,139 @@ Jeśli nie jesteś pewien, powinieneś odrzucić certyfikat. Może to jednak uni
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished">Katalog domowy</translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -904,6 +1037,14 @@ Jeśli nie jesteś pewien, powinieneś odrzucić certyfikat. Może to jednak uni
     <message>
         <source>Engine URL use %s for searchterm</source>
         <translation>Silnik URL używa %s do wyszukiwania</translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-webcat-pl.ts
+++ b/translations/harbour-webcat-pl.ts
@@ -578,11 +578,11 @@ Jeśli nie jesteś pewien, powinieneś odrzucić certyfikat. Może to jednak uni
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-pl.ts
+++ b/translations/harbour-webcat-pl.ts
@@ -566,6 +566,10 @@ Jeśli nie jesteś pewien, powinieneś odrzucić certyfikat. Może to jednak uni
         <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat-ru.ts
+++ b/translations/harbour-webcat-ru.ts
@@ -448,6 +448,46 @@ If you are unsure reject the certificate. That might lead to a non loading websi
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
         <translation type="unfinished"></translation>
@@ -491,18 +531,6 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stop loading the current website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -515,31 +543,7 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -551,15 +555,15 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1039,11 +1043,11 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <source>BB10 Hardware Keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-ru.ts
+++ b/translations/harbour-webcat-ru.ts
@@ -578,11 +578,11 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-ru.ts
+++ b/translations/harbour-webcat-ru.ts
@@ -446,6 +446,139 @@ If you are unsure reject the certificate. That might lead to a non loading websi
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -903,6 +1036,14 @@ If you are unsure reject the certificate. That might lead to a non loading websi
     </message>
     <message>
         <source>Engine URL use %s for searchterm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-ru.ts
+++ b/translations/harbour-webcat-ru.ts
@@ -566,6 +566,10 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat-sv.ts
+++ b/translations/harbour-webcat-sv.ts
@@ -449,6 +449,46 @@ Om du är osäker, bör du förkasta certifikatet. Det kan dock leda till att we
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
         <translation type="unfinished"></translation>
@@ -492,18 +532,6 @@ Om du är osäker, bör du förkasta certifikatet. Det kan dock leda till att we
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stop loading the current website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -516,31 +544,7 @@ Om du är osäker, bör du förkasta certifikatet. Det kan dock leda till att we
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -552,15 +556,15 @@ Om du är osäker, bör du förkasta certifikatet. Det kan dock leda till att we
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1040,11 +1044,11 @@ Om du är osäker, bör du förkasta certifikatet. Det kan dock leda till att we
         <translation>Sökmotor-URL, använd %s för sökterm</translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <source>BB10 Hardware Keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-sv.ts
+++ b/translations/harbour-webcat-sv.ts
@@ -567,6 +567,10 @@ Om du är osäker, bör du förkasta certifikatet. Det kan dock leda till att we
         <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat-sv.ts
+++ b/translations/harbour-webcat-sv.ts
@@ -447,6 +447,139 @@ Om du är osäker, bör du förkasta certifikatet. Det kan dock leda till att we
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished">Hem</translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -905,6 +1038,14 @@ Om du är osäker, bör du förkasta certifikatet. Det kan dock leda till att we
     <message>
         <source>Engine URL use %s for searchterm</source>
         <translation>Sökmotor-URL, använd %s för sökterm</translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-webcat-sv.ts
+++ b/translations/harbour-webcat-sv.ts
@@ -579,11 +579,11 @@ Om du är osäker, bör du förkasta certifikatet. Det kan dock leda till att we
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-zh_CN.ts
+++ b/translations/harbour-webcat-zh_CN.ts
@@ -446,6 +446,46 @@ If you are unsure reject the certificate. That might lead to a non loading websi
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
         <translation type="unfinished"></translation>
@@ -489,18 +529,6 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stop loading the current website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -513,31 +541,7 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -549,15 +553,15 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1036,11 +1040,11 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <source>BB10 Hardware Keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-zh_CN.ts
+++ b/translations/harbour-webcat-zh_CN.ts
@@ -576,11 +576,11 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat-zh_CN.ts
+++ b/translations/harbour-webcat-zh_CN.ts
@@ -564,6 +564,10 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat-zh_CN.ts
+++ b/translations/harbour-webcat-zh_CN.ts
@@ -444,6 +444,139 @@ If you are unsure reject the certificate. That might lead to a non loading websi
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -900,6 +1033,14 @@ If you are unsure reject the certificate. That might lead to a non loading websi
     </message>
     <message>
         <source>Engine URL use %s for searchterm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat.ts
+++ b/translations/harbour-webcat.ts
@@ -446,6 +446,46 @@ If you are unsure reject the certificate. That might lead to a non loading websi
 <context>
     <name>KeyboardCommands</name>
     <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Esc</source>
         <comment>Key</comment>
         <translation type="unfinished"></translation>
@@ -489,18 +529,6 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload current website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page History: Go forward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stop loading the current website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -513,31 +541,7 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open new tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open new window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close current tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to next tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Switch to previous tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open new private window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show in-page search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -549,15 +553,15 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle reader mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Focus URL bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1036,11 +1040,11 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BB10 Hardware Keyboard shortcuts</source>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
+        <source>BB10 Hardware Keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat.ts
+++ b/translations/harbour-webcat.ts
@@ -576,11 +576,11 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are or try them out.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-webcat.ts
+++ b/translations/harbour-webcat.ts
@@ -564,6 +564,10 @@ If you are unsure reject the certificate. That might lead to a non loading websi
         <source>Reload current website</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeyboardOverviewPage</name>

--- a/translations/harbour-webcat.ts
+++ b/translations/harbour-webcat.ts
@@ -444,6 +444,139 @@ If you are unsure reject the certificate. That might lead to a non loading websi
     </message>
 </context>
 <context>
+    <name>KeyboardCommands</name>
+    <message>
+        <source>Esc</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <comment>Key</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll current website to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page History: Go forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop loading the current website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add current website as a bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show list of bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open new private window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start in-page search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle reader mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus URL bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close current WebCat window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardOverviewPage</name>
+    <message>
+        <source>Current Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected BB10 (Blackberry 10) compatible keyboard shortcuts. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have selected keyboard shortcuts which mimic some current popular browsers. Take a look at the list below to see what they are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MediaDownloadRec</name>
     <message>
         <source>Opening...</source>
@@ -900,6 +1033,14 @@ If you are unsure reject the certificate. That might lead to a non loading websi
     </message>
     <message>
         <source>Engine URL use %s for searchterm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BB10 Hardware Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When unchecked, common multi-key shortcuts from other browsers are used</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
The main goal of this PR is to enable productivity features already present in some web applications by (optionally) using common desktop browser key bindings rather than the thumb-key optimized BB10 layout while keeping the BB10 bindings default. 

## Main Features
 - A new bool setting called useBB10KeyboardShortcuts was added
 - The former Keyboard logic been restructured in a more modular way and pulled out of FirstPage.qml. Stylewise I chose verbosity over brevity to keep it easier to read.
 - Some "common" key bindings have been added
 - An overview page for the currently selected bindings has been created. Its content is generated from the set bindings themselves. If keys are pressed on the overview page, the corresponding row is highlighted and scrolled into view.
 - German translation for new strings is included.

## Additional Changes
- searchText: Hide field on Esc press; Focus Webview (to re-enable key bindings) after hiding/searching
- urlText: append .com with Ctrl, .net with Shift and .org with Ctrl+Shift; focus webView on Esc press.
- Bookmarks view: hide on Esc press

## Testing
The binding logic was tested on a Gemini and a TOHKBD. Due to OTG adapter unavailability, no standard keyboard via USB-Host was tested. BT keyboard wasn't tested, as well.
- Gemini PDA: Works as expected.
- Jolla Phone with TOHKBD2: While the TOHKBD works, it does not support sending Ctrl + Shift at the same time (I think those keys are seen as 'sticky' until another key is pressed). At least for "Backtab", a workaround was easily doable without conflicting keys. I'd consider this state useable, even with some "desktop style" combinations not working.